### PR TITLE
feat: add support for emitting events from winsparkle

### DIFF
--- a/lib/src/auto_updater.dart
+++ b/lib/src/auto_updater.dart
@@ -10,11 +10,17 @@ class AutoUpdater {
   /// The shared instance of [AutoUpdater].
   static final AutoUpdater instance = AutoUpdater._();
 
+  /// Event stream for sparkle/winsparkle events
+  final _eventController = StreamController<String>.broadcast();
+  Stream<String> get sparkleEvents => this._eventController.stream;
+
   final MethodChannel _channel = const MethodChannel('auto_updater');
 
   Future<void> _methodCallHandler(MethodCall call) async {
     if (call.method != 'onEvent') throw UnimplementedError();
-    // print(call.arguments['eventName']);
+    if (!call.arguments.containsKey('eventName')) throw UnimplementedError();
+
+    this._eventController.add(call.arguments['eventName']);
   }
 
   /// Sets the url and initialize the auto updater.

--- a/windows/auto_updater.cpp
+++ b/windows/auto_updater.cpp
@@ -3,27 +3,71 @@
 #include <sstream>
 
 namespace {
+// Forward declarations for WinSparkle callbacks
+void __onErrorCallback();
+void __onShutdownRequestCallback();
+void __onDidFindUpdateCallback();
+void __onDidNotFindUpdateCallback();
+void __onUpdateCancelledCallback();
+void __onUpdateSkippedCallback();
+void __onUpdatePostponedCallback();
+void __onUpdateDismissedCallback();
+void __onUserRunInstallerCallback();
+
+    
 class AutoUpdater {
- public:
-  AutoUpdater();
+  public:
+    static AutoUpdater* GetInstance();  
+ 
+    AutoUpdater();
 
-  virtual ~AutoUpdater();
+    virtual ~AutoUpdater();
 
-  void AutoUpdater::SetFeedURL(std::string feedURL);
-  void AutoUpdater::CheckForUpdates();
-  void AutoUpdater::CheckForUpdatesWithoutUI();
-  void AutoUpdater::SetScheduledCheckInterval(int interval);
+    void AutoUpdater::SetFeedURL(std::string feedURL);
+    void AutoUpdater::CheckForUpdates();
+    void AutoUpdater::CheckForUpdatesWithoutUI();
+    void AutoUpdater::SetScheduledCheckInterval(int interval);
 
- private:
+    void AutoUpdater::RegisterCallbacks(
+        std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> ptr);
+    void AutoUpdater::OnWinSparkleEvent(std::string eventName);
+
+  private:
+    static AutoUpdater* lazySingleton;
+   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> _channel;
 };
 
-AutoUpdater::AutoUpdater() {}
+AutoUpdater* AutoUpdater::lazySingleton = nullptr;
+
+AutoUpdater* AutoUpdater::GetInstance() {
+  return lazySingleton;
+}
+
+AutoUpdater::AutoUpdater() {
+  if (lazySingleton != nullptr) {
+    throw std::invalid_argument("AutoUpdater has already been initialized");
+  }
+
+  lazySingleton = this;
+}
 
 AutoUpdater::~AutoUpdater() {}
 
 void AutoUpdater::SetFeedURL(std::string feedURL) {
   win_sparkle_set_appcast_url(feedURL.c_str());
   win_sparkle_init();
+
+  win_sparkle_set_error_callback(__onErrorCallback);
+  win_sparkle_set_shutdown_request_callback(__onShutdownRequestCallback);
+  win_sparkle_set_did_find_update_callback(__onDidFindUpdateCallback);
+  win_sparkle_set_did_not_find_update_callback(__onDidNotFindUpdateCallback);
+  win_sparkle_set_update_cancelled_callback(__onUpdateCancelledCallback);
+
+  // TODO: These will be supported once we update WinSparkle to >0.8.0
+  // win_sparkle_set_update_skipped_callback(__onUpdateSkippedCallback);
+  // win_sparkle_set_update_postponed_callback(__onUpdatePostponedCallback);
+  // win_sparkle_set_update_dismissed_callback(__onUpdateDismissedCallback);
+  // win_sparkle_set_user_run_installer_callback(__onUserRunInstallerCallback);
 }
 
 void AutoUpdater::CheckForUpdates() {
@@ -38,4 +82,77 @@ void AutoUpdater::SetScheduledCheckInterval(int interval) {
   win_sparkle_set_update_check_interval(interval);
 }
 
+void AutoUpdater::RegisterCallbacks(
+    std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> ptr) {
+  _channel = std::move(ptr);
+}
+
+void AutoUpdater::OnWinSparkleEvent(std::string eventName) {
+  if (_channel == nullptr) return;
+
+  this->_channel->InvokeMethod(
+    "onEvent",
+    std::make_unique<flutter::EncodableValue>(
+      flutter::EncodableMap({
+        {
+          flutter::EncodableValue("eventName"),
+          flutter::EncodableValue(eventName)
+        }
+      })));
+}
+
+
+void __onErrorCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("error");
+}
+
+void __onShutdownRequestCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("shutdownRequest");
+}
+
+void __onDidFindUpdateCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("didFindUpdate");
+}
+
+void __onDidNotFindUpdateCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("didNotFindUpdate");
+}
+
+void __onUpdateCancelledCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("updateCancelled");
+}
+
+void __onUpdateSkippedCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("updateSkipped");
+}
+
+void __onUpdatePostponedCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("updatePostponed");
+}
+
+void __onUpdateDismissedCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("updateDismissed");
+}
+
+void __onUserRunInstallerCallback() {
+  AutoUpdater* autoUpdater = AutoUpdater::GetInstance();
+  if (autoUpdater == nullptr) return;
+  autoUpdater->OnWinSparkleEvent("userRunInstaller");
+}
 }  // namespace


### PR DESCRIPTION
This PR adds a `sparkleEvents` property to `autoUpdater`, which is a `Stream<String>` that a user can use to listen to callback events emitted by WinSparkle such as `didFindUpdate` or `didNotFindUpdate`.

On the Windows side, callbacks are registered in `setFeedUrl`, because currently WinSparkle is only initialized after this is called.

There might be a better way to handle the callbacks (without moving the channel pointer) but I'm no C++ expert, so this is the best solution I could come up with.

The events that can currently be emitted are:
* `error`
* `shutdownRequest`
* `didFindUpdate`
* `didNotFindUpdate`
* `updateCancelled`

There is a different subset of events existing in the OSX implementation but these are the ones WinSparkle 0.7.0 supports. 

If that's OK for you, I'd proceed with:
1. [this MR]
2. Update WinSparkle to `0.8.0`
3. Implement the remaining events and adjusting the MacOS Swift code to match the Windows side