### PR TITLE
Fix network port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ void main() async {
   // Must add this line.
   WidgetsFlutterBinding.ensureInitialized();
 
-  String feedURL = 'http://localhost:5000/appcast.xml';
+  String feedURL = 'http://localhost:5002/appcast.xml';
   await autoUpdater.setFeedURL(feedURL);
   await autoUpdater.checkForUpdates();
   await autoUpdater.setScheduledCheckInterval(3600);


### PR DESCRIPTION
In the README the network port provided to the app is not the same as the one the RSS feed is served on.