### PR TITLE
fix: Correct typo in public key generation instructions

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -165,7 +165,7 @@ updates. It should appear like this:
 ```
 Generated two files:
 dsa_priv.pem: your private key. Keep it secret and don't share it!
-dsa_pub.pem: public counterpart to include in youe app.
+dsa_pub.pem: public counterpart to include in your app.
 BACK UP YOUR PRIVATE KEY AND KEEP IT SAFE!
 If you lose it, your users will be unable to upgrade!
 ```

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Output:
 ```
 Generated two files:
 dsa_priv.pem: your private key. Keep it secret and don't share it!
-dsa_pub.pem: public counterpart to include in youe app.
+dsa_pub.pem: public counterpart to include in your app.
 BACK UP YOUR PRIVATE KEY AND KEEP IT SAFE!
 If you lose it, your users will be unable to upgrade!
 ```

--- a/packages/auto_updater_windows/windows/WinSparkle-0.8.1/bin/generate_keys.bat
+++ b/packages/auto_updater_windows/windows/WinSparkle-0.8.1/bin/generate_keys.bat
@@ -23,7 +23,7 @@ FOR %%i IN ("dsa_priv.pem" "dsa_pub.pem") DO (
 echo[
 echo Generated two files:
 echo dsa_priv.pem: your private key. Keep it secret and don't share it!
-echo dsa_pub.pem: public counterpart to include in youe app.
+echo dsa_pub.pem: public counterpart to include in your app.
 
 echo BACK UP YOUR PRIVATE KEY AND KEEP IT SAFE!
 echo If you lose it, your users will be unable to upgrade!


### PR DESCRIPTION
This pull request includes minor corrections to documentation files. The changes fix a typo in the description of the generated public key file.

Documentation corrections:

* [`README-ZH.md`](diffhunk://#diff-edd5d48a312e7033cddcf73578d4105a1275a3111632f8e9845f6d038d6b15edL168-R168): Corrected the typo "youe" to "your" in the description of the `dsa_pub.pem` file.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L168-R168): Corrected the typo "youe" to "your" in the description of the `dsa_pub.pem` file.
* `generate_keys.bat`: Corrected the typo "youe" to "your" in the description of the `dsa_pub.pem` file.