### PR TITLE
feat: implement support for sparkle channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ English | [简体中文](./README-ZH.md)
       - [setFeedURL](#setfeedurl)
       - [checkForUpdates](#checkforupdates)
       - [setScheduledCheckInterval](#setscheduledcheckinterval)
+      - [setAllowedChannels](#setallowedchannels)
 - [Related Links](#related-links)
 - [License](#license)
 
@@ -71,6 +72,10 @@ Asks the server whether there is an update. You must call setFeedURL before usin
 ##### setScheduledCheckInterval
 
 Sets the auto update check interval, default 86400, minimum 3600, 0 to disable update
+
+##### setAllowedChannels
+
+Sets which channels the app is allowed to receive updates from. On macOS this allows receiving updates from specific channels like 'beta' in addition to the default channel.
 
 <!-- README_DOC_GEN -->
 

--- a/packages/auto_updater/CHANGELOG.md
+++ b/packages/auto_updater/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* [macos] Add support for Sparkle channels via new `setAllowedChannels` method (#74)
+
 ## 1.0.0
 
 * First major release.

--- a/packages/auto_updater/example/lib/pages/home.dart
+++ b/packages/auto_updater/example/lib/pages/home.dart
@@ -49,6 +49,11 @@ class _HomePageState extends State<HomePage> with UpdaterListener {
     await autoUpdater.setScheduledCheckInterval(3600);
   }
 
+  Future<void> _handleClickSetAllowedChannels() async {
+    await autoUpdater.setAllowedChannels(['beta']);
+    BotToast.showText(text: 'Allowed channels set to: beta');
+  }
+
   Widget _buildBody(BuildContext context) {
     return ListView(
       children: <Widget>[
@@ -78,6 +83,12 @@ class _HomePageState extends State<HomePage> with UpdaterListener {
               title: const Text('setScheduledCheckInterval'),
               onTap: () {
                 _handleClickSetScheduledCheckInterval();
+              },
+            ),
+            ListTile(
+              title: const Text('setAllowedChannels'),
+              onTap: () {
+                _handleClickSetAllowedChannels();
               },
             ),
           ],

--- a/packages/auto_updater/lib/src/auto_updater.dart
+++ b/packages/auto_updater/lib/src/auto_updater.dart
@@ -96,6 +96,23 @@ class AutoUpdater {
   Future<void> setScheduledCheckInterval(int interval) {
     return _platform.setScheduledCheckInterval(interval);
   }
+
+  /// Sets which channels the app is allowed to receive updates from.
+  ///
+  /// On macOS this allows receiving updates from specific channels
+  /// like 'beta' in addition to the default channel. If this is not called, the app will
+  /// only receive updates from the default channel.
+  ///
+  /// This has no effect on platforms other than macOS.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Allow updates from both default channel and beta channel
+  /// autoUpdater.setAllowedChannels(['beta']);
+  /// ```
+  Future<void> setAllowedChannels(List<String> channels) {
+    return _platform.setAllowedChannels(channels);
+  }
 }
 
 final autoUpdater = AutoUpdater.instance;

--- a/packages/auto_updater/pubspec.yaml
+++ b/packages/auto_updater/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_updater
 description: This plugin allows Flutter desktop apps to automatically update themselves (based on sparkle and winsparkle).
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/leanflutter/auto_updater
 
 platforms:
@@ -15,8 +15,8 @@ environment:
   flutter: ">=3.3.0"
 
 dependencies:
-  auto_updater_macos: ^1.0.0
-  auto_updater_platform_interface: ^1.0.0
+  auto_updater_macos: ^1.1.0
+  auto_updater_platform_interface: ^1.1.0
   auto_updater_windows: ^1.0.0
   flutter:
     sdk: flutter

--- a/packages/auto_updater_macos/CHANGELOG.md
+++ b/packages/auto_updater_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* Add support for Sparkle channels via new `setAllowedChannels` method and the `allowedChannels` delegate.
+
 ## 1.0.0
 
 * First major release.

--- a/packages/auto_updater_macos/macos/Classes/AutoUpdater.swift
+++ b/packages/auto_updater_macos/macos/Classes/AutoUpdater.swift
@@ -43,6 +43,7 @@ public class AutoUpdater: NSObject, SPUUpdaterDelegate {
     var _userDriver: SPUStandardUserDriver?
     var _updater: SPUUpdater?
     var feedURL: URL?
+    var allowedChannels: Set<String>?
     public var onEvent:((String, NSDictionary) -> Void)?
     
     override init() {
@@ -79,6 +80,10 @@ public class AutoUpdater: NSObject, SPUUpdaterDelegate {
     
     public func setScheduledCheckInterval(_ interval: Int) {
         _updater?.updateCheckInterval = TimeInterval(interval)
+    }
+    
+    public func setAllowedChannels(_ channels: [String]) {
+        self.allowedChannels = Set(channels)
     }
     
     // SPUUpdaterDelegate
@@ -124,6 +129,10 @@ public class AutoUpdater: NSObject, SPUUpdaterDelegate {
         ]
         _emitEvent("before-quit-for-update", data)
         return true
+    }
+    
+    public func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        return allowedChannels ?? Set<String>()
     }
     
     public func _emitEvent(_ eventName: String, _ data: NSDictionary) {

--- a/packages/auto_updater_macos/macos/Classes/AutoUpdaterMacosPlugin.swift
+++ b/packages/auto_updater_macos/macos/Classes/AutoUpdaterMacosPlugin.swift
@@ -58,6 +58,11 @@ public class AutoUpdaterMacosPlugin: NSObject, FlutterPlugin,FlutterStreamHandle
             autoUpdater.setScheduledCheckInterval(interval)
             result(true)
             break
+        case "setAllowedChannels":
+            let channels = args["channels"] as! [String]
+            autoUpdater.setAllowedChannels(channels)
+            result(true)
+            break
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/packages/auto_updater_macos/pubspec.yaml
+++ b/packages/auto_updater_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_updater_macos
 description: macOS implementation of the auto_updater plugin.
-version: 1.0.0
+version: 1.1.0
 repository: https://github.com/leanflutter/auto_updater/tree/main/packages/auto_updater_macos
 
 environment:

--- a/packages/auto_updater_platform_interface/CHANGELOG.md
+++ b/packages/auto_updater_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* Add support for Sparkle channels via new `setAllowedChannels` method.
+
 ## 1.0.0
 
 * First major release.

--- a/packages/auto_updater_platform_interface/lib/src/auto_updater_method_channel.dart
+++ b/packages/auto_updater_platform_interface/lib/src/auto_updater_method_channel.dart
@@ -44,4 +44,12 @@ class MethodChannelAutoUpdater extends AutoUpdaterPlatform {
     };
     await methodChannel.invokeMethod('setScheduledCheckInterval', arguments);
   }
+  
+  @override
+  Future<void> setAllowedChannels(List<String> channels) async {
+    final Map<String, dynamic> arguments = {
+      'channels': channels,
+    };
+    await methodChannel.invokeMethod('setAllowedChannels', arguments);
+  }
 }

--- a/packages/auto_updater_platform_interface/lib/src/auto_updater_platform_interface.dart
+++ b/packages/auto_updater_platform_interface/lib/src/auto_updater_platform_interface.dart
@@ -42,4 +42,15 @@ abstract class AutoUpdaterPlatform extends PlatformInterface {
       'setScheduledCheckInterval() has not been implemented.',
     );
   }
+
+  /// Sets which channels the app is allowed to receive updates from.
+  ///
+  /// On macOS this allows receiving updates from specific channels
+  /// like 'beta' in addition to the default channel. If this is not called, the app will
+  /// only receive updates from the default channel.
+  ///
+  /// This has no effect on platforms other than macOS. See https://github.com/vslavik/winsparkle/issues/248
+  Future<void> setAllowedChannels(List<String> channels) async {
+    throw UnimplementedError('setAllowedChannels() has not been implemented.');
+  }
 }

--- a/packages/auto_updater_platform_interface/pubspec.yaml
+++ b/packages/auto_updater_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_updater_platform_interface
 description: A common platform interface for the auto_updater plugin.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/leanflutter/auto_updater/blob/main/packages/auto_updater_platform_interface
 
 environment:


### PR DESCRIPTION
This PR adds support for sparkle channels.

- Adds a new `setAllowedChannels` method to the platform interface
- Implements the required native code in the macOS implementation
- Updates documentation to explain the feature

With this change, apps can specify which channels they want to receive updates from, such as 'beta' channel in addition to the default channel.

Note: This feature is only supported on macOS.

Fixes  #74